### PR TITLE
Version 0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -308,7 +308,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vmf-forge"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "derive_more",
  "indexmap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,6 +37,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_more"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "093242cf7570c207c83073cf82f79706fe7b8317e98620a47d5be7c3d8497678"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -290,6 +310,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 name = "vmf-forge"
 version = "0.2.0"
 dependencies = [
+ "derive_more",
  "indexmap",
  "pest",
  "pest_derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ pest_derive = "2.7.15"
 serde = { version = "1.0.217", features = ["derive"] }
 indexmap = { version = "2.7.1", features = ["serde"] }
 serde_json = "1.0.137"
+derive_more = { version = "^2.0.1", features = ["deref", "deref_mut", "into_iterator"] }
 
 [dev-dependencies]
 pretty_assertions = "1.4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vmf-forge"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 authors = ["laVashik <contact@lavashik.lol>"]
 description = "A parser for Valve Map Format (VMF) files"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <div>
-  <img align="left" style="margin-right: 20px;" src="https://i.imgur.com/5cKkQsj.png" alt="logo">
+  <img align="left" style="margin-right: 20px;" width="84px" src="https://i.imgur.com/5cKkQsj.png" alt="logo">
   <h1>VMF_Forge</h1>
 </div>
 
@@ -8,7 +8,7 @@
 [![Docs.rs](https://docs.rs/vmf-forge/badge.svg)](https://docs.rs/vmf-forge)
 ![License](https://img.shields.io/github/license/IaVashik/vmf-forge)
 
-`vmf-forge` is a Rust library for parsing, manipulating, and serializing Valve Map Format (VMF) files used in Source Engine games. This project is currently **work in progress**.
+`vmf-forge` is a Rust library for parsing, manipulating, and serializing Valve Map Format (VMF) files used in Source Engine games. 
 
 ## Features
 
@@ -22,7 +22,7 @@ Add `vmf-forge` to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-vmf-forge = "0.2.0"
+vmf-forge = "0.3.0"
 ```
 
 ## Usage Example

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,7 @@ use serde::{Deserialize, Serialize};
 use std::fs::File;
 use std::io::{Read, Write};
 use std::path::Path;
+use std::str::FromStr;
 
 pub mod parser;
 pub(crate) mod utils;
@@ -130,7 +131,7 @@ impl VmfFile {
     /// let vmf_file = VmfFile::parse_file(&mut file);
     /// assert!(vmf_file.is_ok());
     /// ```
-    pub fn parse_file(file: &mut File) -> VmfResult<Self> {
+    pub fn parse_file(file: &mut impl Read) -> VmfResult<Self> {
         let mut content = Vec::new();
         file.read_to_end(&mut content)?;
         let content = String::from_utf8_lossy(&content);
@@ -193,6 +194,43 @@ impl VmfFile {
         Ok(())
     }
 
+    /// Merges the contents of another `VmfFile` into this one.
+    ///
+    /// This method combines the `visgroups`, `world` solids (both visible and hidden),
+    /// `entities`, `hiddens`, and `cordons` from the `other` `VmfFile` into the
+    /// current `VmfFile`.  `versioninfo`, `viewsettings`, and `cameras` are
+    /// *not* merged; the original values in `self` are retained.
+    ///
+    /// This method is experimental and its behavior may change in future versions.
+    /// It does not handle potential ID conflicts between the two VMF files.
+    ///
+    /// # Arguments
+    ///
+    /// * `other` - The `VmfFile` to merge into this one.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use vmf_forge::prelude::*;
+    ///
+    /// let mut vmf1 = VmfFile::open("map1.vmf").unwrap();
+    /// let vmf2 = VmfFile::open("map2.vmf").unwrap();
+    ///
+    /// vmf1.merge(vmf2);
+    ///
+    /// // vmf1 now contains the combined contents of both files.
+    /// ```
+    pub fn merge(&mut self, other: VmfFile) {
+        self.visgroups.groups.extend(other.visgroups.groups);
+        self.world.solids.extend(other.world.solids);
+        self.world.hidden.extend(other.world.hidden);
+
+        self.entities.extend(other.entities);
+        self.hiddens.extend(other.hiddens);
+
+        self.cordons.extend(other.cordons.cordons);
+    }
+
     /// Converts the `VmfFile` to a string in VMF format.
     ///
     /// # Returns
@@ -223,6 +261,14 @@ impl VmfFile {
         output.push_str(&self.cordons.to_vmf_string(0));
 
         output
+    }
+}
+
+impl FromStr for VmfFile {
+    type Err = VmfError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        VmfFile::parse(s)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,7 +54,7 @@ pub trait VmfSerializable {
 }
 
 /// Represents a parsed VMF file.
-#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq)]
 pub struct VmfFile {
     /// The path to the VMF file, if known.
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -42,13 +42,12 @@ pub fn parse_vmf(input: &str) -> VmfResult<VmfFile> {
                 "world" => vmf_file.world = World::try_from(block)?,
 
                 // -- entities
-                "entity" => vmf_file.entities.vec.push(Entity::try_from(block)?),
+                "entity" => vmf_file.entities.push(Entity::try_from(block)?),
                 "hidden" => {
                     if let Some(hidden_block) = block.blocks.first() {
-                        vmf_file
-                            .hiddens
-                            .vec
-                            .push(Entity::try_from(hidden_block.to_owned())?)
+                        let mut ent = Entity::try_from(hidden_block.to_owned())?;
+                        ent.is_hidden = true;
+                        vmf_file.hiddens.push(ent)
                     }
                 }
 
@@ -56,7 +55,7 @@ pub fn parse_vmf(input: &str) -> VmfResult<VmfFile> {
                 "cameras" => vmf_file.cameras = Cameras::try_from(block)?,
                 "cordons" => vmf_file.cordons = Cordons::try_from(block)?,
                 // for old version of VMF
-                "cordon" => vmf_file.cordons.cordons.push(Cordon::try_from(block)?),
+                "cordon" => vmf_file.cordons.push(Cordon::try_from(block)?),
                 // ....
                 _ => {
                     #[cfg(feature = "debug_assert_info")]

--- a/src/vmf/common.rs
+++ b/src/vmf/common.rs
@@ -11,7 +11,7 @@ use crate::{
 };
 
 /// Represents the editor data of a VMF entity or solid.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Editor {
     /// The color of the entity in the editor, in "R G B" format.
     pub color: String,

--- a/src/vmf/entities.rs
+++ b/src/vmf/entities.rs
@@ -44,14 +44,14 @@ impl Entity {
     /// ```
     /// use vmf_forge::prelude::*;
     ///
-    /// let entity = Entity::new("info_player_start", "1");
+    /// let entity = Entity::new("info_player_start", 1);
     /// assert_eq!(entity.classname(), Some("info_player_start"));
-    /// assert_eq!(entity.id(), Some("1"));
+    /// assert_eq!(entity.id(), 1);
     /// ```
-    pub fn new(classname: impl Into<String>, id: impl Into<String>) -> Self {
+    pub fn new(classname: impl Into<String>, id: u64) -> Self {
         let mut key_values = IndexMap::new();
         key_values.insert("classname".to_string(), classname.into());
-        key_values.insert("id".to_string(), id.into());
+        key_values.insert("id".to_string(), id.to_string());
         Entity {
             key_values,
             connections: None,
@@ -144,11 +144,11 @@ impl Entity {
     }
 
     /// Returns the ID of the entity.
-    pub fn id(&self) -> i32 {
+    pub fn id(&self) -> u64 {
         self.key_values
             .get("id")
-            .and_then(|s| s.parse::<i32>().ok())
-            .unwrap_or(-1)
+            .and_then(|s| s.parse::<u64>().ok())
+            .unwrap_or(0)
     }
 
     /// Returns the model of the entity.
@@ -176,7 +176,7 @@ impl Entity {
     /// ```
     /// use vmf_forge::prelude::*;
     ///
-    /// let mut entity = Entity::new("logic_relay", "1");
+    /// let mut entity = Entity::new("logic_relay", 1);
     /// entity.add_connection("OnTrigger", "my_door", "Open", "", 0.0, -1);
     /// ```
     pub fn add_connection(

--- a/src/vmf/entities.rs
+++ b/src/vmf/entities.rs
@@ -12,7 +12,7 @@ use super::common::Editor;
 use super::world::Solid;
 
 /// Represents an entity in a VMF file.
-#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq)]
 pub struct Entity {
     /// The key-value pairs associated with this entity.
     pub key_values: IndexMap<String, String>,
@@ -320,7 +320,9 @@ impl VmfSerializable for Entity {
 }
 
 /// Represents a collection of entities in a VMF file.
-#[derive(Debug, Default, Clone, Serialize, Deserialize, Deref, DerefMut, IntoIterator)]
+#[derive(
+    Debug, Default, Clone, Serialize, Deserialize, PartialEq, Deref, DerefMut, IntoIterator,
+)]
 pub struct Entities {
     /// The vector of entities.
     pub vec: Vec<Entity>,

--- a/src/vmf/entities.rs
+++ b/src/vmf/entities.rs
@@ -4,9 +4,9 @@ use crate::{
     errors::{VmfError, VmfResult},
     VmfBlock, VmfSerializable,
 };
+use derive_more::{Deref, DerefMut, IntoIterator};
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
-use derive_more::{Deref, DerefMut, IntoIterator};
 
 use super::common::Editor;
 use super::world::Solid;
@@ -145,7 +145,10 @@ impl Entity {
 
     /// Returns the ID of the entity.
     pub fn id(&self) -> i32 {
-        self.key_values.get("id").and_then(|s| s.parse::<i32>().ok()).unwrap_or(-1)
+        self.key_values
+            .get("id")
+            .and_then(|s| s.parse::<i32>().ok())
+            .unwrap_or(-1)
     }
 
     /// Returns the model of the entity.
@@ -216,7 +219,7 @@ impl Entity {
     pub fn has_connection(&self, output: &str, input: &str) -> bool {
         if let Some(connections) = &self.connections {
             connections.iter().any(|(o, i)| o == output && i == input)
-        }else{
+        } else {
             false
         }
     }
@@ -433,7 +436,11 @@ impl Entities {
     /// An `Option` containing the removed `Entity`, if found. Returns `None`
     /// if no entity with the given ID exists.
     pub fn remove_entity(&mut self, entity_id: i32) -> Option<Entity> {
-        if let Some(index) = self.vec.iter().position(|e| e.key_values.get("id") == Some(&entity_id.to_string())) {
+        if let Some(index) = self
+            .vec
+            .iter()
+            .position(|e| e.key_values.get("id") == Some(&entity_id.to_string()))
+        {
             Some(self.vec.remove(index))
         } else {
             None
@@ -447,10 +454,10 @@ impl Entities {
     /// * `key` - The key to check.
     /// * `value` - The value to compare against.
     pub fn remove_by_keyvalue(&mut self, key: &str, value: &str) {
-        self.vec.retain(|ent| ent.key_values.get(key).map(|v| v != value).unwrap_or(true));
+        self.vec
+            .retain(|ent| ent.key_values.get(key).map(|v| v != value).unwrap_or(true));
     }
 }
-
 
 // utils func
 fn process_connections(map: IndexMap<String, String>) -> Option<Vec<(String, String)>> {

--- a/src/vmf/entities.rs
+++ b/src/vmf/entities.rs
@@ -6,10 +6,7 @@ use crate::{
 };
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
-use std::{
-    ops::{Deref, DerefMut},
-    vec,
-};
+use derive_more::{Deref, DerefMut, IntoIterator};
 
 use super::common::Editor;
 use super::world::Solid;
@@ -27,6 +24,202 @@ pub struct Entity {
     pub solids: Option<Vec<Solid>>,
     /// The editor data for this entity.
     pub editor: Editor,
+    /// Indicates if the entity is hidden within the editor.  This field
+    /// is primarily used when parsing a `hidden` block within a VMF file,
+    /// and is not serialized back when writing the VMF.
+    #[serde(default, skip_serializing)]
+    pub is_hidden: bool,
+}
+
+impl Entity {
+    /// Creates a new `Entity` with the specified classname and ID.
+    ///
+    /// # Arguments
+    ///
+    /// * `classname` - The classname of the entity (e.g., "func_detail", "info_player_start").
+    /// * `id` - The unique ID of the entity.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use vmf_forge::prelude::*;
+    ///
+    /// let entity = Entity::new("info_player_start", "1");
+    /// assert_eq!(entity.classname(), Some("info_player_start"));
+    /// assert_eq!(entity.id(), Some("1"));
+    /// ```
+    pub fn new(classname: impl Into<String>, id: impl Into<String>) -> Self {
+        let mut key_values = IndexMap::new();
+        key_values.insert("classname".to_string(), classname.into());
+        key_values.insert("id".to_string(), id.into());
+        Entity {
+            key_values,
+            connections: None,
+            solids: None,
+            editor: Editor::default(),
+            is_hidden: false,
+        }
+    }
+
+    /// Sets a key-value pair for the entity.  If the key already exists,
+    /// its value is updated.
+    ///
+    /// # Arguments
+    ///
+    /// * `key` - The key to set.
+    /// * `value` - The value to set for the key.
+    pub fn set(&mut self, key: String, value: String) {
+        self.key_values.insert(key, value);
+    }
+
+    /// Removes a key-value pair from the entity, preserving the order of other keys.
+    ///
+    /// # Arguments
+    ///
+    /// * `key` - The key to remove.
+    ///
+    /// # Returns
+    ///
+    /// An `Option` containing the removed value, if the key was present.
+    pub fn remove_key(&mut self, key: &str) -> Option<String> {
+        self.key_values.shift_remove(key)
+    }
+
+    /// Removes a key-value pair from the entity, potentially changing the order of other keys.
+    /// This is faster than `remove_key` but does not preserve insertion order.
+    ///
+    /// # Arguments
+    ///
+    /// * `key` - The key to remove.
+    ///
+    /// # Returns
+    ///
+    /// An `Option` containing the removed value, if the key was present.
+    pub fn swap_remove_key(&mut self, key: &str) -> Option<String> {
+        self.key_values.swap_remove(key)
+    }
+
+    /// Gets the value associated with the given key.
+    ///
+    /// # Arguments
+    ///
+    /// * `key` - The key to get the value for.
+    ///
+    /// # Returns
+    ///
+    /// An `Option` containing a reference to the value, if the key is present.
+    pub fn get(&self, key: &str) -> Option<&String> {
+        self.key_values.get(key)
+    }
+
+    /// Gets a mutable reference to the value associated with the given key.
+    ///
+    /// # Arguments
+    ///
+    /// * `key` - The key to get the value for.
+    ///
+    /// # Returns
+    ///
+    /// An `Option` containing a mutable reference to the value, if the key is present.
+    pub fn get_mut(&mut self, key: &str) -> Option<&mut String> {
+        self.key_values.get_mut(key)
+    }
+
+    /// Returns the classname of the entity.
+    ///
+    /// # Returns
+    ///
+    /// An `Option` containing the classname, if it exists.
+    pub fn classname(&self) -> Option<&str> {
+        self.key_values.get("classname").map(|s| s.as_str())
+    }
+
+    /// Returns the targetname of the entity.
+    ///
+    /// # Returns
+    ///
+    /// An `Option` containing the targetname, if it exists.
+    pub fn targetname(&self) -> Option<&str> {
+        self.key_values.get("targetname").map(|s| s.as_str())
+    }
+
+    /// Returns the ID of the entity.
+    pub fn id(&self) -> i32 {
+        self.key_values.get("id").and_then(|s| s.parse::<i32>().ok()).unwrap_or(-1)
+    }
+
+    /// Returns the model of the entity.
+    ///
+    /// # Returns
+    ///
+    /// An `Option` containing the model path, if it exists.
+    pub fn model(&self) -> Option<&str> {
+        self.key_values.get("model").map(|s| s.as_str())
+    }
+
+    /// Adds an output connection to the entity.
+    ///
+    /// # Arguments
+    ///
+    /// * `output` - The name of the output on this entity.
+    /// * `target_entity` - The targetname of the entity to connect to.
+    /// * `input` - The name of the input on the target entity.
+    /// * `parms` - The parameters to pass to the input.
+    /// * `delay` - The delay before the input is triggered, in seconds.
+    /// * `fire_limit` - The number of times the output can be fired (-1 for unlimited).
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use vmf_forge::prelude::*;
+    ///
+    /// let mut entity = Entity::new("logic_relay", "1");
+    /// entity.add_connection("OnTrigger", "my_door", "Open", "", 0.0, -1);
+    /// ```
+    pub fn add_connection(
+        &mut self,
+        output: impl Into<String>,
+        target_entity: impl AsRef<str>,
+        input: impl AsRef<str>,
+        parms: impl AsRef<str>,
+        delay: f32,
+        fire_limit: i32,
+    ) {
+        let input_result = format!(
+            "{}\x1B{}\x1B{}\x1B{}\x1B{}",
+            target_entity.as_ref(),
+            input.as_ref(),
+            parms.as_ref(),
+            delay,
+            fire_limit
+        );
+        if let Some(connections) = &mut self.connections {
+            connections.push((output.into(), input_result));
+        } else {
+            self.connections = Some(vec![(output.into(), input_result)]);
+        }
+    }
+
+    /// Removes all connections from this entity.
+    pub fn clear_connections(&mut self) {
+        self.connections = None;
+    }
+
+    /// Checks if a specific connection exists.
+    ///
+    /// # Arguments
+    /// * `output` The output to check
+    /// * `input` The input to check
+    ///
+    /// # Returns
+    /// * `true` if the connection exists, `false` otherwise.
+    pub fn has_connection(&self, output: &str, input: &str) -> bool {
+        if let Some(connections) = &self.connections {
+            connections.iter().any(|(o, i)| o == output && i == input)
+        }else{
+            false
+        }
+    }
 }
 
 impl TryFrom<VmfBlock> for Entity {
@@ -124,24 +317,10 @@ impl VmfSerializable for Entity {
 }
 
 /// Represents a collection of entities in a VMF file.
-#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize, Deref, DerefMut, IntoIterator)]
 pub struct Entities {
     /// The vector of entities.
     pub vec: Vec<Entity>,
-}
-
-impl Deref for Entities {
-    type Target = Vec<Entity>;
-
-    fn deref(&self) -> &Self::Target {
-        &self.vec
-    }
-}
-
-impl DerefMut for Entities {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.vec
-    }
 }
 
 impl Entities {
@@ -242,7 +421,36 @@ impl Entities {
     ) -> impl Iterator<Item = &'a mut Entity> + 'a {
         self.find_by_keyvalue_mut("model", model)
     }
+
+    /// Removes an entity by its ID.
+    ///
+    /// # Arguments
+    ///
+    /// * `entity_id` - The ID of the entity to remove.
+    ///
+    /// # Returns
+    ///
+    /// An `Option` containing the removed `Entity`, if found. Returns `None`
+    /// if no entity with the given ID exists.
+    pub fn remove_entity(&mut self, entity_id: i32) -> Option<Entity> {
+        if let Some(index) = self.vec.iter().position(|e| e.key_values.get("id") == Some(&entity_id.to_string())) {
+            Some(self.vec.remove(index))
+        } else {
+            None
+        }
+    }
+
+    /// Removes all entities that have a matching key-value pair.
+    ///
+    /// # Arguments
+    ///
+    /// * `key` - The key to check.
+    /// * `value` - The value to compare against.
+    pub fn remove_by_keyvalue(&mut self, key: &str, value: &str) {
+        self.vec.retain(|ent| ent.key_values.get(key).map(|v| v != value).unwrap_or(true));
+    }
 }
+
 
 // utils func
 fn process_connections(map: IndexMap<String, String>) -> Option<Vec<(String, String)>> {

--- a/src/vmf/metadata.rs
+++ b/src/vmf/metadata.rs
@@ -12,7 +12,7 @@ use crate::{
 };
 
 /// Represents the version info of a VMF file.
-#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq)]
 pub struct VersionInfo {
     /// The editor version.
     pub editor_version: i32,
@@ -92,7 +92,9 @@ impl VmfSerializable for VersionInfo {
 }
 
 /// Represents a collection of VisGroups in a VMF file.
-#[derive(Debug, Default, Clone, Serialize, Deserialize, Deref, DerefMut, IntoIterator)]
+#[derive(
+    Debug, Default, Clone, Serialize, Deserialize, PartialEq, Deref, DerefMut, IntoIterator,
+)]
 pub struct VisGroups {
     /// The list of VisGroups.
     #[deref]
@@ -150,7 +152,7 @@ impl VmfSerializable for VisGroups {
 }
 
 /// Represents a VisGroup in a VMF file.
-#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq)]
 pub struct VisGroup {
     /// The name of the VisGroup.
     pub name: String,
@@ -242,7 +244,7 @@ impl VmfSerializable for VisGroup {
 }
 
 /// Represents the view settings of a VMF file.
-#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq)]
 pub struct ViewSettings {
     /// Whether snapping to the grid is enabled.
     pub snap_to_grid: bool,

--- a/src/vmf/metadata.rs
+++ b/src/vmf/metadata.rs
@@ -1,5 +1,7 @@
 //! This module provides structures for representing metadata blocks in a VMF file, such as version info, visgroups, and view settings.
 
+use derive_more::{Deref, DerefMut, IntoIterator};
+
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 
@@ -90,9 +92,10 @@ impl VmfSerializable for VersionInfo {
 }
 
 /// Represents a collection of VisGroups in a VMF file.
-#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize, Deref, DerefMut, IntoIterator)]
 pub struct VisGroups {
     /// The list of VisGroups.
+    #[deref]
     pub groups: Vec<VisGroup>,
 }
 

--- a/src/vmf/regions.rs
+++ b/src/vmf/regions.rs
@@ -1,8 +1,8 @@
 //! This module provides structures for representing region-specific data in a VMF file, such as cameras and cordons.
 
+use derive_more::{Deref, DerefMut};
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
-use derive_more::{Deref, DerefMut};
 
 use crate::utils::{get_key, parse_hs_key, To01String};
 use crate::{

--- a/src/vmf/regions.rs
+++ b/src/vmf/regions.rs
@@ -2,6 +2,7 @@
 
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
+use derive_more::{Deref, DerefMut};
 
 use crate::utils::{get_key, parse_hs_key, To01String};
 use crate::{
@@ -10,11 +11,13 @@ use crate::{
 };
 
 /// Represents the camera data in a VMF file.
-#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize, Deref, DerefMut)]
 pub struct Cameras {
     /// The index of the active camera.
     pub active: i8,
     /// The list of cameras.
+    #[deref]
+    #[deref_mut]
     pub cams: Vec<Camera>,
 }
 
@@ -114,11 +117,13 @@ impl From<Camera> for VmfBlock {
 }
 
 /// Represents the cordons data in a VMF file.
-#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize, Deref, DerefMut)]
 pub struct Cordons {
     /// The index of the active cordon.
     pub active: i8,
     /// The list of cordons.
+    #[deref]
+    #[deref_mut]
     pub cordons: Vec<Cordon>,
 }
 

--- a/src/vmf/regions.rs
+++ b/src/vmf/regions.rs
@@ -11,7 +11,7 @@ use crate::{
 };
 
 /// Represents the camera data in a VMF file.
-#[derive(Debug, Default, Clone, Serialize, Deserialize, Deref, DerefMut)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, Deref, DerefMut)]
 pub struct Cameras {
     /// The index of the active camera.
     pub active: i8,
@@ -83,7 +83,7 @@ impl VmfSerializable for Cameras {
 }
 
 /// Represents a single camera in a VMF file.
-#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq)]
 pub struct Camera {
     /// The position of the camera in the VMF coordinate system.
     pub position: String, // vertex
@@ -117,7 +117,7 @@ impl From<Camera> for VmfBlock {
 }
 
 /// Represents the cordons data in a VMF file.
-#[derive(Debug, Default, Clone, Serialize, Deserialize, Deref, DerefMut)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, Deref, DerefMut)]
 pub struct Cordons {
     /// The index of the active cordon.
     pub active: i8,
@@ -185,7 +185,7 @@ impl VmfSerializable for Cordons {
 }
 
 /// Represents a single cordon in a VMF file.
-#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq)]
 pub struct Cordon {
     /// The name of the cordon.
     pub name: String,

--- a/src/vmf/world.rs
+++ b/src/vmf/world.rs
@@ -11,7 +11,7 @@ use crate::{
 };
 
 /// Represents the world block in a VMF file.
-#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq)]
 pub struct World {
     /// The key-value pairs associated with the world.
     pub key_values: IndexMap<String, String>,
@@ -124,7 +124,7 @@ impl VmfSerializable for World {
 }
 
 /// Represents a solid object in the VMF world.
-#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq)]
 pub struct Solid {
     /// The unique ID of the solid.
     pub id: u64,
@@ -207,7 +207,7 @@ impl VmfSerializable for Solid {
 }
 
 /// Represents a side of a solid object in the VMF world.
-#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq)]
 pub struct Side {
     /// The unique ID of the side.
     pub id: u32,
@@ -350,7 +350,7 @@ macro_rules! find_block {
 }
 
 /// Represents the displacement information for a side.
-#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq)]
 pub struct DispInfo {
     /// The power of the displacement map (2, 3, or 4).
     pub power: u8,
@@ -582,7 +582,7 @@ impl DispInfo {
 }
 
 /// Represents rows of data for displacement information, such as normals, distances, offsets, etc.
-#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct DispRows {
     /// The rows of data, each represented as a string.
     pub rows: Vec<String>,
@@ -659,7 +659,7 @@ impl DispRows {
 }
 
 /// Represents a group in the VMF world.
-#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Group {
     /// The unique ID of the group.
     pub id: u32,

--- a/tests/entities_test.rs
+++ b/tests/entities_test.rs
@@ -108,6 +108,7 @@ mod tests {
                 color: "255 255 255".to_string(),
                 ..Default::default()
             },
+            is_hidden: false,
         };
 
         let expected = "\
@@ -141,6 +142,7 @@ mod tests {
                 color: "255 255 255".to_string(),
                 ..Default::default()
             },
+            is_hidden: false,
         };
 
         let block: VmfBlock = entity.into();
@@ -166,7 +168,7 @@ mod tests {
     #[test]
     fn test_entities_find_by_keyvalue() {
         let mut entities = Entities::default();
-        entities.vec.push(Entity {
+        entities.push(Entity {
             key_values: {
                 let mut map = IndexMap::new();
                 map.insert("classname".to_string(), "entity1".to_string());
@@ -175,7 +177,7 @@ mod tests {
             },
             ..Default::default()
         });
-        entities.vec.push(Entity {
+        entities.push(Entity {
             key_values: {
                 let mut map = IndexMap::new();
                 map.insert("classname".to_string(), "entity2".to_string());
@@ -184,7 +186,7 @@ mod tests {
             },
             ..Default::default()
         });
-        entities.vec.push(Entity {
+        entities.push(Entity {
             key_values: {
                 let mut map = IndexMap::new();
                 map.insert("classname".to_string(), "entity1".to_string());
@@ -226,8 +228,8 @@ mod tests {
             },
             ..Default::default()
         };
-        entities.vec.push(entity1);
-        entities.vec.push(entity2);
+        entities.push(entity1);
+        entities.push(entity2);
 
         let found_entities: Vec<_> = entities
             .find_by_keyvalue_mut("classname", "entity1")
@@ -235,13 +237,13 @@ mod tests {
         assert_eq!(found_entities[0].key_values.get("key1").unwrap(), "value1");
         assert_eq!(found_entities.len(), 1);
 
-        assert_eq!(entities.vec[1].key_values.get("key1").unwrap(), "value2");
+        assert_eq!(entities[1].key_values.get("key1").unwrap(), "value2");
     }
 
     #[test]
     fn test_entities_find_by_classname() {
         let mut entities = Entities::default();
-        entities.vec.push(Entity {
+        entities.push(Entity {
             key_values: {
                 let mut map = IndexMap::new();
                 map.insert("classname".to_string(), "info_player_start".to_string());
@@ -249,7 +251,7 @@ mod tests {
             },
             ..Default::default()
         });
-        entities.vec.push(Entity {
+        entities.push(Entity {
             key_values: {
                 let mut map = IndexMap::new();
                 map.insert("classname".to_string(), "entity2".to_string());
@@ -266,7 +268,7 @@ mod tests {
     #[test]
     fn test_entities_find_by_name() {
         let mut entities = Entities::default();
-        entities.vec.push(Entity {
+        entities.push(Entity {
             key_values: {
                 let mut map = IndexMap::new();
                 map.insert("targetname".to_string(), "my_entity".to_string());
@@ -274,7 +276,7 @@ mod tests {
             },
             ..Default::default()
         });
-        entities.vec.push(Entity {
+        entities.push(Entity {
             key_values: {
                 let mut map = IndexMap::new();
                 map.insert("targetname".to_string(), "another_entity".to_string());
@@ -290,7 +292,7 @@ mod tests {
     #[test]
     fn test_entities_find_by_classname_mut() {
         let mut entities = Entities::default();
-        entities.vec.push(Entity {
+        entities.push(Entity {
             key_values: {
                 let mut map = IndexMap::new();
                 map.insert("classname".to_string(), "info_player_start".to_string());
@@ -307,7 +309,7 @@ mod tests {
     #[test]
     fn test_entities_find_by_name_mut() {
         let mut entities = Entities::default();
-        entities.vec.push(Entity {
+        entities.push(Entity {
             key_values: {
                 let mut map = IndexMap::new();
                 map.insert("targetname".to_string(), "my_entity".to_string());
@@ -355,6 +357,7 @@ mod tests {
                 logical_pos: Some("[0 -5268]".to_string()),
                 ..Default::default()
             },
+            is_hidden: false,
         };
 
         let expected = "\
@@ -379,5 +382,178 @@ mod tests {
         }\n";
 
         assert_eq!(entity.to_vmf_string(0), expected);
+    }
+
+    // NEW tests (ver 3)
+    #[test]
+    fn entity_new() {
+        let entity = Entity::new("info_player_start", 1);
+        assert_eq!(entity.classname(), Some("info_player_start"));
+        assert_eq!(entity.id(), 1);
+        assert!(entity.connections.is_none());
+        assert!(entity.solids.is_none());
+        assert_eq!(entity.editor.color, "255 255 255"); // Check default editor
+        assert!(!entity.is_hidden);
+    }
+
+    #[test]
+    fn entity_set() {
+        let mut entity = Entity::new("info_player_start", 1);
+        entity.set("targetname".to_string(), "my_player_start".to_string());
+        assert_eq!(entity.targetname(), Some("my_player_start"));
+
+        entity.set("origin".to_string(), "10 20 30".to_string());
+        assert_eq!(entity.get("origin"), Some(&"10 20 30".to_string()));
+    }
+
+    #[test]
+    fn entity_remove_key() {
+        let mut entity = Entity::new("info_player_start", 1);
+        entity.set("targetname".to_string(), "my_player_start".to_string());
+
+        let removed_value = entity.remove_key("targetname");
+        assert_eq!(removed_value, Some("my_player_start".to_string()));
+        assert!(entity.targetname().is_none());
+
+        let none_value = entity.remove_key("nonexistent_key");
+        assert!(none_value.is_none());
+    }
+
+    #[test]
+    fn entity_swap_remove_key() {
+        let mut entity = Entity::new("info_player_start", 1);
+        entity.set("targetname".to_string(), "my_player_start".to_string());
+
+        let removed_value = entity.swap_remove_key("targetname");
+        assert_eq!(removed_value, Some("my_player_start".to_string()));
+        assert!(entity.targetname().is_none());
+
+        let none_value = entity.swap_remove_key("nonexistent_key");
+        assert!(none_value.is_none());
+    }
+
+    #[test]
+    fn entity_get() {
+        let mut entity = Entity::new("info_player_start", 1);
+        entity.set("targetname".to_string(), "my_player_start".to_string());
+
+        assert_eq!(
+            entity.get("targetname"),
+            Some(&"my_player_start".to_string())
+        );
+        assert!(entity.get("nonexistent_key").is_none());
+    }
+
+    #[test]
+    fn entity_get_mut() {
+        let mut entity = Entity::new("info_player_start", 1);
+        entity.set("targetname".to_string(), "my_player_start".to_string());
+
+        if let Some(targetname) = entity.get_mut("targetname") {
+            *targetname = "new_targetname".to_string();
+        }
+
+        assert_eq!(entity.targetname(), Some("new_targetname"));
+        assert!(entity.get_mut("nonexistent_key").is_none());
+    }
+
+    #[test]
+    fn entity_classname_targetname_id_model() {
+        let mut entity = Entity::new("info_player_start", 1);
+        entity.set("targetname".to_string(), "my_player_start".to_string());
+        entity.set("model".to_string(), "*1".to_string());
+
+        assert_eq!(entity.classname(), Some("info_player_start"));
+        assert_eq!(entity.targetname(), Some("my_player_start"));
+        assert_eq!(entity.id(), 1);
+        assert_eq!(entity.model(), Some("*1"));
+
+        let mut entity2 = Entity::new("func_brush", 2); // different classname
+        entity2.set("targetname".to_string(), "my_brush".to_string());
+        assert_eq!(entity2.classname(), Some("func_brush"));
+    }
+
+    #[test]
+    fn entity_add_connection() {
+        let mut entity = Entity::new("logic_relay", 1);
+        entity.add_connection("OnTrigger", "my_door", "Open", "", 0.0, -1);
+        entity.add_connection("OnTrigger", "my_sound", "PlaySound", "bang", 0.5, 1);
+
+        assert!(entity.connections.is_some());
+        let connections = entity.connections.unwrap();
+        assert_eq!(connections.len(), 2);
+        assert_eq!(
+            connections[0],
+            ("OnTrigger".to_string(), "my_door\x1BOpen\x1B\x1B0\x1B-1".to_string())
+        );
+        assert_eq!(
+            connections[1],
+            (
+                "OnTrigger".to_string(),
+                "my_sound\x1BPlaySound\x1Bbang\x1B0.5\x1B1".to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn entity_has_connection() {
+        let mut entity = Entity::new("logic_relay", 1);
+        entity.add_connection("OnTrigger", "my_door", "Open", "", 0.0, -1);
+
+        assert!(entity.has_connection("OnTrigger", "my_door\x1BOpen\x1B\x1B0\x1B-1"));
+        assert!(!entity.has_connection("OnTrigger", "my_door\x1BClose\x1B\x1B0\x1B-1"));
+        assert!(!entity.has_connection("OnStartTouch", "my_door\x1BOpen\x1B\x1B0\x1B-1"));
+    }
+
+    #[test]
+    fn entity_clear_connections() {
+        let mut entity = Entity::new("logic_relay", 1);
+        entity.add_connection("OnTrigger", "my_door", "Open", "", 0.0, -1);
+        entity.clear_connections();
+        assert!(entity.connections.is_none());
+    }
+
+    // Tests for Entities (the collection)
+
+    #[test]
+    fn entities_remove_entity() {
+        let mut entities = Entities::default();
+        let entity1 = Entity::new("info_player_start", 1);
+        let entity2 = Entity::new("func_detail", 2);
+        entities.push(entity1.clone());
+        entities.push(entity2);
+
+        let removed_entity = entities.remove_entity(1);
+        assert_eq!(removed_entity, Some(entity1));
+        assert_eq!(entities.len(), 1);
+
+        let non_existent = entities.remove_entity(3);
+        assert!(non_existent.is_none());
+    }
+
+    #[test]
+    fn test_remove_by_keyvalue() {
+        let mut entities = Entities::default();
+        entities.push(Entity::new("info_player_start", 1));
+        entities.push(Entity::new("info_player_deathmatch", 2));
+        entities.push(Entity::new("info_player_start", 3));
+
+        entities.remove_by_keyvalue("classname", "info_player_start");
+        assert_eq!(entities.len(), 1);
+        assert_eq!(entities[0].id(), 2);
+    }
+
+    #[test]
+    fn remove_by_keyvalue_no_match() {
+        let mut entities = Entities::default();
+        entities.push(Entity::new("info_player_start", 1));
+        entities.remove_by_keyvalue("classname", "func_door"); // No entities with this classname
+        assert_eq!(entities.len(), 1);
+    }
+    #[test]
+    fn remove_by_keyvalue_empty() {
+        let mut entities = Entities::default();
+        entities.remove_by_keyvalue("classname", "anything"); // Should not panic
+        assert_eq!(entities.len(), 0);
     }
 }


### PR DESCRIPTION
**Key Changes:**

*   **Enhanced Entity Management:**
    *   Added `Entity::new`, `set`, `remove_key`, `swap_remove_key`, `get`, `get_mut`, `classname`, `targetname`, `id`, `model` methods for easier creation and modification of entities.
    *   Added `Entity::add_connection`, `clear_connections`, `has_connection` methods for managing entity connections.
    *   Added `Entities::remove_entity`, `remove_by_keyvalue` methods for removing entities from collections.
    *   Added `is_hidden` fields to the `Entity` struct.

*   **Experimental VMF Merging:**
    *   Introduced an *experimental* `VmfFile::merge` method for combining the contents of two VMF files.  This method merges `visgroups`, `world` solids, `entities`, `hiddens`, and `cordons`.  **Note:**  This method does *not* handle ID conflicts and is subject to change.

*   **Improved Comparison:**
    *   Implemented `PartialEq` for core data structs.

*   **Code Refactoring:**
    *   Implemented `Deref` and `DerefMut` for `Entities`, `VisGroups`, `Cameras`, and `Cordons` to provide more direct access to their inner data.

**Breaking Changes:**

* While no methods were removed, the addition of `is_hidden` to the `Entity` struct *could* be considered breaking if someone was exhaustively matching on all fields. Given the field's purpose (internal parsing) and that it is marked as skipped for serialization, the breakage is very minimal and limited to very specific use cases.  The benefits of correct `hidden` block parsing outweigh this minor potential breakage. The `new` function signature was updated.